### PR TITLE
Force getMetaData() via P & D messages even in simple mode

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/QueryExecutor.java
@@ -131,6 +131,11 @@ public interface QueryExecutor extends TypeTransferModeRegistry {
   int QUERY_READ_ONLY_HINT = 2048;
 
   /**
+   * MatrixDB: Flag indicating that extended mode are forced for the given query.
+   */
+  int QUERY_FORCE_EXECUTE_AS_EXTENDED = 4096;
+
+  /**
    * Execute a Query, passing results to a provided ResultHandler.
    *
    * @param query the query to execute; must be a query returned from calling

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -312,6 +312,10 @@ public class QueryExecutorImpl extends QueryExecutorBase {
   //
 
   private int updateQueryMode(int flags) {
+    // MatrixDB: Am I forced to use extended mode?
+    if ((flags & QueryExecutor.QUERY_FORCE_EXECUTE_AS_EXTENDED) != 0)
+      return flags & ~QUERY_EXECUTE_AS_SIMPLE;
+
     switch (getPreferQueryMode()) {
       case SIMPLE:
         return flags | QUERY_EXECUTE_AS_SIMPLE;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -1173,6 +1173,13 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
 
       int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_DESCRIBE_ONLY
           | QueryExecutor.QUERY_SUPPRESS_BEGIN;
+
+      // MatrixDB: Force getting metadata in extended mode even in simple mode.
+      // getMetaData() can be called before binding of parameters, so the "?" in
+      // the query cannot be expanded, the SQL would be sent to database with "?"
+      // unexpanded, this will cause syntax error of course.
+      flags |= QueryExecutor.QUERY_FORCE_EXECUTE_AS_EXTENDED;
+
       StatementResultHandler handler = new StatementResultHandler();
       connection.getQueryExecutor().execute(preparedQuery.query, preparedParameters, handler, 0, 0,
           flags);
@@ -1751,6 +1758,13 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   public ParameterMetaData getParameterMetaData() throws SQLException {
     int flags = QueryExecutor.QUERY_ONESHOT | QueryExecutor.QUERY_DESCRIBE_ONLY
         | QueryExecutor.QUERY_SUPPRESS_BEGIN;
+
+    // MatrixDB: Force getting metadata in extended mode even in simple mode.
+    // getMetaData() can be called before binding of parameters, so the "?" in
+    // the query cannot be expanded, the SQL would be sent to database with "?"
+    // unexpanded, this will cause syntax error of course.
+    flags |= QueryExecutor.QUERY_FORCE_EXECUTE_AS_EXTENDED;
+
     StatementResultHandler handler = new StatementResultHandler();
     connection.getQueryExecutor().execute(preparedQuery.query, preparedParameters, handler, 0, 0,
         flags);


### PR DESCRIPTION
PreparedStatement.getMetaData() can be called before binding of parameters, so the "?" in the query cannot be expanded, the SQL would be sent to database with "?" unexpanded, this will cause syntax error of course.

To let this work we have to force the method run via the parse & describe libpq messages.